### PR TITLE
Adds CRA build fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hugorezende/antd-img-crop",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@babel/runtime": "^7.12.1",
     "image-blob-reduce": "^2.2.2",
+    "pica": "^6.1.1",
     "react-easy-crop": "^3.3.0"
   },
   "devDependencies": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -5,7 +5,10 @@ import LocaleReceiver from 'antd/es/locale-provider/LocaleReceiver';
 import Modal from 'antd/es/modal';
 import Slider from 'antd/es/slider';
 import './index.less';
+//@ts-ignore
 import ImageBlobReduce from 'image-blob-reduce';
+//@ts-ignore
+import Pica from 'pica';
 
 const pkg = 'antd-img-crop';
 const noop = () => {};
@@ -168,7 +171,8 @@ const ImgCrop = forwardRef((props, ref) => {
             let finalFile;
 
             if (resizeMaxSize) {
-              const reduce = new ImageBlobReduce();
+              const pica = Pica();
+              const reduce = new ImageBlobReduce({ pica });
               finalFile = await reduce.toBlob(file, { max: resizeMaxSize });
               finalFile.name = file.name;
               finalFile.lastModifiedDate = new Date();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,6 +2026,13 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+image-blob-reduce@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/image-blob-reduce/-/image-blob-reduce-2.2.3.tgz#b5be0ee5dfbcd6a827edab27a051887be77ada77"
+  integrity sha512-VZTYIQ4x8F+gNn4KKP6us5ASkv65FyHNQT0TLuVbnqsfcvbSDwFekraiz81B14e0AX5i2P5osUxyUT8fUTwMzQ==
+  dependencies:
+    pica "^6.1.1"
+
 image-size@~0.5.0:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"


### PR DESCRIPTION
I have a CRA app and I was trying to use your version of antd-img-crop to make it compatible with Safari in iOS, but kept getting these errors only on the deployed version:

```
ReferenceError: o is not defined
    at e (blob:http://localhost:5000/2bdae74b-66c2-443f-8a8f-6b18edc7fb4c:1:313)
    at blob:http://localhost:5000/2bdae74b-66c2-443f-8a8f-6b18edc7fb4c:1:352
```

After some research, I found that there's a compatibility issue between Pica/ImageBlobReduce and CRA's minifier or something similar. 

It's been addressed here and there's a proposed solution that worked for me:
#https://github.com/nodeca/image-blob-reduce/issues/17

Added the proposed solution to the package and it seems to be working. Thanks for your work, I'm leaving the pull request here in case you want to pull this solution!

Cheers!
